### PR TITLE
Fix: #95 Login button is replaced with UserAccount after login

### DIFF
--- a/app/(marketing)/layout.tsx
+++ b/app/(marketing)/layout.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link"
+import { notFound } from "next/navigation"
 
 import { marketingConfig } from "@/config/marketing"
+import { getCurrentUser } from "@/lib/session"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 import { MainNav } from "@/components/main-nav"
 import { SiteFooter } from "@/components/site-footer"
+import { UserAccountNav } from "@/components/user-account-nav"
 
 interface MarketingLayoutProps {
   children: React.ReactNode
@@ -13,22 +16,34 @@ interface MarketingLayoutProps {
 export default async function MarketingLayout({
   children,
 }: MarketingLayoutProps) {
+  const user = await getCurrentUser()
+
   return (
     <div className="flex min-h-screen flex-col">
       <header className="container z-40 bg-background">
         <div className="flex h-20 items-center justify-between py-6">
           <MainNav items={marketingConfig.mainNav} />
-          <nav>
-            <Link
-              href="/login"
-              className={cn(
-                buttonVariants({ variant: "secondary", size: "sm" }),
-                "px-4"
-              )}
-            >
-              Login
-            </Link>
-          </nav>
+          {user ? (
+            <UserAccountNav
+              user={{
+                name: user.name,
+                email: user.email,
+                image: user.image,
+              }}
+            />
+          ) : (
+            <nav>
+              <Link
+                href="/login"
+                className={cn(
+                  buttonVariants({ variant: "secondary", size: "sm" }),
+                  "px-4"
+                )}
+              >
+                Login
+              </Link>
+            </nav>
+          )}
         </div>
       </header>
       <main className="flex-1">{children}</main>


### PR DESCRIPTION
Fixes issue #95 where Login button still shows up in navbar even after the user logs in. Replaces Login button with UserAccountNav component when user is authenticated.

Not Logged in - 
![Screenshot 2023-07-19 at 12 57 07 PM](https://github.com/shadcn-ui/taxonomy/assets/39588858/4195af3e-4a0e-4406-9895-115bee829406)

Logged in - 
![Screenshot 2023-07-19 at 12 58 33 PM](https://github.com/shadcn-ui/taxonomy/assets/39588858/3935c2e6-a982-4e54-bf17-4753f59bbeed)
