### PR TITLE
Do no shrink new post button on mobile

### DIFF
--- a/components/post-create-button.tsx
+++ b/components/post-create-button.tsx
@@ -61,6 +61,7 @@ export function PostCreateButton({
     <button
       onClick={onClick}
       className={cn(
+        "shrink-0",
         buttonVariants({ variant }),
         {
           "cursor-not-allowed opacity-60": isLoading,


### PR DESCRIPTION
I think it looks better
before 
<img width="618" alt="Screenshot 2023-08-21 at 6 05 05 PM" src="https://github.com/shadcn-ui/taxonomy/assets/4012422/4c6c82ef-3dc5-49dc-b80c-9dd76e7887c8">
after
<img width="618" alt="Screenshot 2023-08-21 at 6 05 25 PM" src="https://github.com/shadcn-ui/taxonomy/assets/4012422/15b319e2-4fd4-4e40-83de-3710ca6242f5">
