### PR TITLE
Fix:#192

### DIFF
--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import Image from "next/image"
+import Image, { ImageProps } from "next/image"
 import { useMDXComponent } from "next-contentlayer/hooks"
 
 import { cn } from "@/lib/utils"
@@ -91,14 +91,7 @@ const components = {
       {...props}
     />
   ),
-  img: ({
-    className,
-    alt,
-    ...props
-  }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img className={cn("rounded-md border", className)} alt={alt} {...props} />
-  ),
+  Image: (props: ImageProps) => <Image {...props} />,
   hr: ({ ...props }) => <hr className="my-4 md:my-8" {...props} />,
   table: ({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) => (
     <div className="my-6 w-full overflow-y-auto">
@@ -147,7 +140,6 @@ const components = {
       {...props}
     />
   ),
-  Image,
   Callout,
   Card: MdxCard,
 }


### PR DESCRIPTION
- fix(mdx-components.tsx): add support for Image component from next/image package in the components object

**fixing:**
![image](https://github.com/shadcn-ui/taxonomy/assets/81274178/e8f69e3f-a8d0-40dc-bc80-526e6055b630)

It appears that props passed to Next Image are not read correctly by Contentlayer with Nextjs 13.4, so change the way you pass the Image component in your mdx-components file

```
import Image, { ImageProps } from "next/image"

const components = {
  // Image,
  Image: (props: ImageProps) => <Image {...props} />,
}
```

https://github.com/contentlayerdev/contentlayer/issues/506#issuecomment-1665583574