### PR TITLE
fix: fixes the issue regarding mobile navigation does not close on click

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -19,6 +19,24 @@ export function MainNav({ items, children }: MainNavProps) {
   const segment = useSelectedLayoutSegment()
   const [showMobileMenu, setShowMobileMenu] = React.useState<boolean>(false)
 
+  const toggleMobileMenu = () => {
+    setShowMobileMenu(!showMobileMenu)
+  }
+
+  React.useEffect(() => {
+    const closeMobileMenuOnClickOutside = (event: MouseEvent) => {
+      if (showMobileMenu) {
+        setShowMobileMenu(false)
+      }
+    }
+
+    document.addEventListener("click", closeMobileMenuOnClickOutside)
+
+    return () => {
+      document.removeEventListener("click", closeMobileMenuOnClickOutside)
+    }
+  }, [showMobileMenu])
+
   return (
     <div className="flex gap-6 md:gap-10">
       <Link href="/" className="hidden items-center space-x-2 md:flex">
@@ -48,7 +66,7 @@ export function MainNav({ items, children }: MainNavProps) {
       ) : null}
       <button
         className="flex items-center space-x-2 md:hidden"
-        onClick={() => setShowMobileMenu(!showMobileMenu)}
+        onClick={toggleMobileMenu}
       >
         {showMobileMenu ? <Icons.close /> : <Icons.logo />}
         <span className="font-bold">Menu</span>


### PR DESCRIPTION
### What change does this PR introduce?
This PR fixes the mobile navigation now when anywhere clicks anywhere on the screen while the nav bar is open it will close also when the user goes to another link the nav bar will close. 

Fixes #26

### Other Information


https://github.com/shadcn-ui/taxonomy/assets/120767897/e27432d2-06e3-44fa-a542-b254b0d4e803

