### PR TITLE
fix: footer_Component

### DIFF
--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -8,7 +8,7 @@ import { ModeToggle } from "@/components/mode-toggle"
 export function SiteFooter({ className }: React.HTMLAttributes<HTMLElement>) {
   return (
     <footer className={cn(className)}>
-      <div className="container flex flex-col items-center justify-between gap-4 py-10 md:h-24 md:flex-row md:py-0">
+      <div className="container flex flex-col items-center justify-center gap-4 py-10 md:h-24 md:flex-row md:py-0">
         <div className="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0">
           <Icons.logo />
           <p className="text-center text-sm leading-loose md:text-left">


### PR DESCRIPTION
## What does this PR do?

Improved UI - Footer UI has unnecessary margin between theme icon and text has removed. now the text is in center.

Fixes #305 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![Screenshot 2024-06-30 131359](https://github.com/shadcn-ui/taxonomy/assets/121685601/7985cebd-a69b-4e67-9a78-96d0130e0ded)


## Type of change

- Bug fix (non-breaking change which fixes an issue)


